### PR TITLE
[OPS-1301] Use baton-ci app token in capabilities_and_config.yaml

### DIFF
--- a/.github/workflows/capabilities_and_config.yaml
+++ b/.github/workflows/capabilities_and_config.yaml
@@ -10,10 +10,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Mint baton-ci app token
+        id: ci-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.BATON_CI_CLIENT_ID }}
+          private-key: ${{ secrets.BATON_CI_SECRET_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.RELENG_GITHUB_TOKEN }}
+          token: ${{ steps.ci-token.outputs.token }}
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
Replace the long-lived `RELENG_GITHUB_TOKEN` PAT with a short-lived `baton-ci` app token scoped to the current repo.

Mirrors the OPS-1300 templated workflow pattern. With the Connector Rules ruleset hardened, the legacy PAT only continues to work because of the temp org-admin mitigation; this PR replaces it with the proper App-token bypass actor before that mitigation is removed.

Linear: [OPS-1301](https://linear.app/ductone/issue/OPS-1301)

🤖 Generated with [Claude Code](https://claude.com/claude-code)